### PR TITLE
replace deprecated and removed rb_cData with rb_cObject

### DIFF
--- a/sdk/ext/ovirtsdk4c/ov_http_request.c
+++ b/sdk/ext/ovirtsdk4c/ov_http_request.c
@@ -344,7 +344,7 @@ static VALUE ov_http_request_initialize(int argc, VALUE* argv, VALUE self) {
 
 void ov_http_request_define(void) {
     /* Define the class: */
-    ov_http_request_class = rb_define_class_under(ov_module, "HttpRequest", rb_cData);
+    ov_http_request_class = rb_define_class_under(ov_module, "HttpRequest", rb_cObject);
 
     /* Define the constructor: */
     rb_define_alloc_func(ov_http_request_class, ov_http_request_alloc);

--- a/sdk/ext/ovirtsdk4c/ov_http_response.c
+++ b/sdk/ext/ovirtsdk4c/ov_http_response.c
@@ -184,7 +184,7 @@ static VALUE ov_http_response_initialize(int argc, VALUE* argv, VALUE self) {
 
 void ov_http_response_define(void) {
     /* Define the class: */
-    ov_http_response_class = rb_define_class_under(ov_module, "HttpResponse", rb_cData);
+    ov_http_response_class = rb_define_class_under(ov_module, "HttpResponse", rb_cObject);
 
     /* Define the constructor: */
     rb_define_alloc_func(ov_http_response_class, ov_http_response_alloc);

--- a/sdk/ext/ovirtsdk4c/ov_http_transfer.c
+++ b/sdk/ext/ovirtsdk4c/ov_http_transfer.c
@@ -80,7 +80,7 @@ static VALUE ov_http_transfer_inspect(VALUE self) {
 
 void ov_http_transfer_define(void) {
     /* Define the class: */
-    ov_http_transfer_class = rb_define_class_under(ov_module, "HttpTransfer", rb_cData);
+    ov_http_transfer_class = rb_define_class_under(ov_module, "HttpTransfer", rb_cObject);
 
     /* Define the constructor: */
     rb_define_alloc_func(ov_http_transfer_class, ov_http_transfer_alloc);

--- a/sdk/ext/ovirtsdk4c/ov_xml_reader.c
+++ b/sdk/ext/ovirtsdk4c/ov_xml_reader.c
@@ -430,7 +430,7 @@ void ov_xml_reader_define(void) {
     rb_require("stringio");
 
     /* Define the class: */
-    ov_xml_reader_class = rb_define_class_under(ov_module, "XmlReader", rb_cData);
+    ov_xml_reader_class = rb_define_class_under(ov_module, "XmlReader", rb_cObject);
 
     /* Define the constructor: */
     rb_define_alloc_func(ov_xml_reader_class, ov_xml_reader_alloc);


### PR DESCRIPTION
This enables the gem to work on ruby 3.1.0 and higher - without this, you get invalid symbols when attempting to build on ruby 3.1.  I've tested this also on ruby 2.7, where it does work.