### PR TITLE
Bump API model and metamodel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Version of the metamodel and model used to generate the SDK: -->
-    <metamodel.version>1.3.4</metamodel.version>
-    <model.version>4.4.26</model.version>
+    <metamodel.version>1.3.10</metamodel.version>
+    <model.version>4.6.0</model.version>
 
   </properties>
 


### PR DESCRIPTION
Bumps oVirt Engine API model to 4.6.0 and metamodel to 1.3.10

Signed-off-by: Martin Perina <mperina@redhat.com>
