### PR TITLE
add source code metadata to gemspec

### DIFF
--- a/sdk/ovirt-engine-sdk.gemspec
+++ b/sdk/ovirt-engine-sdk.gemspec
@@ -29,6 +29,12 @@ Gem::Specification.new do |spec|
   spec.license     = 'Apache-2.0'
   spec.homepage    = 'http://ovirt.org'
 
+  spec.metadata = {
+    "changelog_uri" => "https://github.com/oVirt/ovirt-engine-sdk-ruby/blob/master/sdk/CHANGES.adoc",
+    "source_code_uri" => "https://github.com/oVirt/ovirt-engine-sdk-ruby/",
+    "bug_tracker_uri" => "https://github.com/oVirt/ovirt-engine-sdk-ruby/issues",
+  }
+
   # Ruby version:
   spec.required_ruby_version = '>= 2.5'
 


### PR DESCRIPTION
This will meta-data will show up under links in: https://rubygems.org/gems/ovirt-engine-sdk

These are basically only documentation changes (in gemspec)

![SCR-20240911-mphs](https://github.com/user-attachments/assets/368b54ef-b48c-46e7-b4ef-e1d6bb0015aa)
