### PR TITLE
update signature for hash_foreach value

### DIFF
--- a/sdk/ext/ovirtsdk4c/ov_http_client.c
+++ b/sdk/ext/ovirtsdk4c/ov_http_client.c
@@ -491,7 +491,7 @@ static int ov_http_client_debug_function(CURL* handle, curl_infotype type, char*
     ov_http_transfer_ptr(transfer, transfer_ptr);
 
     /* The global interpreter lock may be acquired or not, so we need to check and either call the task directly
-       or else call it after acquiring the lock. Note that the `ruby_thread_has_gvl_p` function that we ue to
+       or else call it after acquiring the lock. Note that the `ruby_thread_has_gvl_p` function that we use to
        check if the GVL is acquired is marked as experimental, and not defined in `thread.h`, so it may be
        removed at any time, but I didn't find any other way to check if the GVL is acquired. */
     context.client = transfer_ptr->client;

--- a/sdk/ext/ovirtsdk4c/ov_http_client.c
+++ b/sdk/ext/ovirtsdk4c/ov_http_client.c
@@ -1006,7 +1006,7 @@ static void ov_http_client_prepare_handle(ov_http_client_object* client_ptr, ov_
 
     /* Set the headers: */
     if (!NIL_P(request_ptr->headers)) {
-        rb_hash_foreach(request_ptr->headers, ov_http_client_add_header, (VALUE) headers);
+        rb_hash_foreach(request_ptr->headers, (int (*)(VALUE, VALUE, VALUE)) ov_http_client_add_header, (VALUE) headers);
     }
     curl_easy_setopt(handle, CURLOPT_HTTPHEADER, *headers);
 

--- a/sdk/ext/ovirtsdk4c/ov_http_client.c
+++ b/sdk/ext/ovirtsdk4c/ov_http_client.c
@@ -34,6 +34,9 @@ limitations under the License.
 #include "ov_http_response.h"
 #include "ov_http_transfer.h"
 
+/* thread.c (export) */
+extern int ruby_thread_has_gvl_p(void);
+
 /* Class: */
 VALUE ov_http_client_class;
 


### PR DESCRIPTION
Resolves one issue in #14

Change
------

Updated c files to fix warnings (that prevent this from building on a mac and linux machine)

Before
------

```bash
gem install ovirt-engine-sdk -v4.6.0
# fail

gem install --verbose ovirt-engine-sdk -v4.6.0 -- --with-cflags="-Wno-error=incompatible-function-pointer-types -Wno-error=implicit-function-declaration"
# succeed
```


After
-----

(hopefully. I can't do this since I can't push the changes)

```bash
gem install ovirt-engine-sdk -v4.6.0
```

---

@sunpoet This is your code change from [freebsd](https://cgit.freebsd.org/ports/commit/?id=463e93ce059522a1f1a93474bb41f90561b77d4f). If this gets merged, you will be able to remove it from your custom patch. Is it ok to apply here? Thnx

If you want me to add attribution and signoff for you, or if you'd prefer creating your own PR. Please let me know.

UPDATE: contact with author and signed off

--

@jhernand I pulled out your c change from #10 - I feel the `gemspec` changes are probably also needed, but trying to keep this as minimal as possible.

I left your signoff for the partial commit, please let me know if you agree or feel this does not properly reflect your intent.

@sandrobonazzola I noticed your commit does not have a Signoff. Please advise