### PR TITLE
Extracted: Update gemspec dependencies for ruby 3

### DIFF
--- a/sdk/.rubocop.yml
+++ b/sdk/.rubocop.yml
@@ -69,7 +69,7 @@ Style/DateTime:
 # to itself. Rubocop doesn't like these tests, but we want them anyhow,
 # so we exclude that spec.
 #
-Lint/UselessComparison:
+Lint/BinaryOperatorWithIdenticalOperands:
   Exclude:
     - 'spec/type_spec.rb'
 Style/NilComparison:
@@ -95,3 +95,21 @@ AllCops:
     - 'lib/ovirtsdk4/version.rb'
     - 'pkg/**/*'
     - 'tmp/**/*'
+
+#
+# This things used to work fine before upgrading Rubocop, and we don't want
+# to address them now. At some point we should remove these lines, check the
+# result and fix the code accordingly.
+#
+Style/RedundantFileExtensionInRequire:
+  Enabled: False
+Style/OptionalBooleanParameter:
+  Enabled: False
+Naming/VariableNumber:
+  Enabled: False
+Style/AccessorGrouping:
+  Enabled: False
+Style/SingleArgumentDig:
+  Enabled: False
+Style/ZeroLengthPredicate:
+  Enabled: False

--- a/sdk/examples/vm_backup.rb
+++ b/sdk/examples/vm_backup.rb
@@ -60,7 +60,7 @@ log.info('Connected to the server.')
 system_service = connection.system_service
 
 # Get the reference to the service that we will use to send events to the audit log:
-events_service = system_service.events_service()
+events_service = system_service.events_service
 
 # In order to send events we need to also send unique integer ids. These should usually come from an external
 # database, but in this example we # will just generate them from the current time in seconds since Jan 1st 1970.

--- a/sdk/ovirt-engine-sdk.gemspec
+++ b/sdk/ovirt-engine-sdk.gemspec
@@ -39,10 +39,11 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.5'
 
   # Build time dependencies:
-  spec.add_development_dependency('rake', '~> 12.3')
-  spec.add_development_dependency('rake-compiler', '~> 1.0')
+  spec.add_development_dependency('rake', '~> 13.1')
+  spec.add_development_dependency('rake-compiler', '~> 1.2')
   spec.add_development_dependency('rspec', '~> 3.7')
-  spec.add_development_dependency('rubocop', '0.79.0')
+  spec.add_development_dependency('rubocop', '1.60.2')
+  spec.add_development_dependency('webrick', '~> 1.8')
   spec.add_development_dependency('yard', '~> 0.9', '>= 0.9.12')
 
   # Run time dependencies:


### PR DESCRIPTION
Currently the SDK doesn't build or work with Ruby 3:

The versions of `rake`, `rubocop` and `webrick` need to be updated to work with Ruby 3.

Notes
---

- This PR is #10 without the `weld` changes.
- I left attribution in place.
- I did trim the git message to just comment on the contents of this PR. But the wording is original.

Thank you @jhernand for the great PR


Disclaimer
---

I am still unable to run `mvn package` locally to build this gem.
If you have suggestions on how I can build/test the packaging of the gem, please share.