### PR TITLE
ovirtsdk4c: fix compiler warnings

### DIFF
--- a/generator/src/main/java/org/ovirt/sdk/ruby/RubyBuffer.java
+++ b/generator/src/main/java/org/ovirt/sdk/ruby/RubyBuffer.java
@@ -171,8 +171,9 @@ public class RubyBuffer {
      */
     public void addLine(String format, Object ... args) {
         StringBuilder buffer = new StringBuilder();
-        Formatter formatter = new Formatter(buffer);
-        formatter.format(format, args);
+        try (Formatter formatter = new Formatter(buffer)) {
+            formatter.format(format, args);
+        }
         String line = buffer.toString();
         addLine(line);
     }
@@ -218,8 +219,9 @@ public class RubyBuffer {
      */
     public void addComment(String format, Object ... args) {
         StringBuilder buffer = new StringBuilder();
-        Formatter formatter = new Formatter(buffer);
-        formatter.format(format, args);
+        try (Formatter formatter = new Formatter(buffer)) {
+            formatter.format(format, args);
+        }
         String line = buffer.toString();
         addComment(line);
     }
@@ -236,8 +238,9 @@ public class RubyBuffer {
     public void addYardTag(String tag, String format, Object ... args) {
         // Format the text and split it into lines:
         StringBuilder text = new StringBuilder();
-        Formatter formatter = new Formatter(text);
-        formatter.format(format, args);
+        try (Formatter formatter = new Formatter(text)) {
+            formatter.format(format, args);
+        }
         String[] lines = text.toString().split("\\n");
 
         // The first line must be prefixed with the name of the tag:

--- a/sdk/ext/ovirtsdk4c/ov_http_request.c
+++ b/sdk/ext/ovirtsdk4c/ov_http_request.c
@@ -45,7 +45,7 @@ static VALUE CONNECT_TIMEOUT_SYMBOL;
 static void ov_http_request_mark(void* vptr) {
     ov_http_request_object* ptr;
 
-    ptr = vptr;
+    ptr = (ov_http_request_object*)vptr;
     rb_gc_mark(ptr->method);
     rb_gc_mark(ptr->url);
     rb_gc_mark(ptr->query);
@@ -62,7 +62,7 @@ static void ov_http_request_mark(void* vptr) {
 static void ov_http_request_free(void* vptr) {
     ov_http_request_object* ptr;
 
-    ptr = vptr;
+    ptr = (ov_http_request_object*)vptr;
     xfree(ptr);
 }
 
@@ -72,7 +72,7 @@ rb_data_type_t ov_http_request_type = {
         .dmark = ov_http_request_mark,
         .dfree = ov_http_request_free,
         .dsize = NULL,
-        .reserved = { NULL, NULL }
+        .reserved = { NULL }
     },
 #ifdef RUBY_TYPED_FREE_IMMEDIATELY
     .parent = NULL,
@@ -305,7 +305,7 @@ static VALUE ov_http_request_inspect(VALUE self) {
 
     ov_http_request_ptr(self, ptr);
     return rb_sprintf(
-        "#<%"PRIsVALUE":%"PRIsVALUE" %"PRIsVALUE">",
+        "#<%" PRIsVALUE ":%" PRIsVALUE " %" PRIsVALUE ">",
         ov_http_request_class,
         ptr->method,
         ptr->url

--- a/sdk/ext/ovirtsdk4c/ov_http_response.c
+++ b/sdk/ext/ovirtsdk4c/ov_http_response.c
@@ -31,7 +31,7 @@ static VALUE MESSAGE_SYMBOL;
 static void ov_http_response_mark(void* vptr) {
     ov_http_response_object* ptr;
 
-    ptr = vptr;
+    ptr = (ov_http_response_object*)vptr;
     rb_gc_mark(ptr->body);
     rb_gc_mark(ptr->code);
     rb_gc_mark(ptr->headers);
@@ -41,7 +41,7 @@ static void ov_http_response_mark(void* vptr) {
 static void ov_http_response_free(void* vptr) {
     ov_http_response_object* ptr;
 
-    ptr = vptr;
+    ptr = (ov_http_response_object*)vptr;
     xfree(ptr);
 }
 
@@ -51,7 +51,7 @@ rb_data_type_t ov_http_response_type = {
         .dmark = ov_http_response_mark,
         .dfree = ov_http_response_free,
         .dsize = NULL,
-        .reserved = { NULL, NULL }
+        .reserved = { NULL }
     },
 #ifdef RUBY_TYPED_FREE_IMMEDIATELY
     .parent = NULL,
@@ -151,7 +151,7 @@ static VALUE ov_http_response_inspect(VALUE self) {
 
     ov_http_response_ptr(self, ptr);
     return rb_sprintf(
-        "#<%"PRIsVALUE":%"PRIsVALUE" %"PRIsVALUE">",
+        "#<%" PRIsVALUE ":%" PRIsVALUE " %" PRIsVALUE ">",
         ov_http_response_class,
         ptr->code,
         ptr->message

--- a/sdk/ext/ovirtsdk4c/ov_http_transfer.c
+++ b/sdk/ext/ovirtsdk4c/ov_http_transfer.c
@@ -27,7 +27,7 @@ VALUE ov_http_transfer_class;
 static void ov_http_transfer_mark(void* vptr) {
     ov_http_transfer_object* ptr;
 
-    ptr = vptr;
+    ptr = (ov_http_transfer_object*)vptr;
     rb_gc_mark(ptr->client);
     rb_gc_mark(ptr->request);
     rb_gc_mark(ptr->response);
@@ -38,7 +38,7 @@ static void ov_http_transfer_mark(void* vptr) {
 static void ov_http_transfer_free(void* vptr) {
     ov_http_transfer_object* ptr;
 
-    ptr = vptr;
+    ptr = (ov_http_transfer_object*)vptr;
     xfree(ptr);
 }
 
@@ -48,7 +48,7 @@ rb_data_type_t ov_http_transfer_type = {
         .dmark = ov_http_transfer_mark,
         .dfree = ov_http_transfer_free,
         .dsize = NULL,
-        .reserved = { NULL, NULL }
+        .reserved = { NULL }
     },
 #ifdef RUBY_TYPED_FREE_IMMEDIATELY
     .parent = NULL,
@@ -75,7 +75,7 @@ static VALUE ov_http_transfer_inspect(VALUE self) {
     ov_http_transfer_object* ptr;
 
     ov_http_transfer_ptr(self, ptr);
-    return rb_sprintf("#<%"PRIsVALUE":%p>", ov_http_transfer_class, ptr);
+    return rb_sprintf("#<%" PRIsVALUE ":%p>", ov_http_transfer_class, ptr);
 }
 
 void ov_http_transfer_define(void) {

--- a/sdk/ext/ovirtsdk4c/ov_xml_reader.c
+++ b/sdk/ext/ovirtsdk4c/ov_xml_reader.c
@@ -72,7 +72,7 @@ rb_data_type_t ov_xml_reader_type = {
         .dmark = ov_xml_reader_mark,
         .dfree = ov_xml_reader_free,
         .dsize = NULL,
-        .reserved = { NULL, NULL }
+        .reserved = { NULL }
     },
 #ifdef RUBY_TYPED_FREE_IMMEDIATELY
     .parent = NULL,

--- a/sdk/ext/ovirtsdk4c/ov_xml_writer.c
+++ b/sdk/ext/ovirtsdk4c/ov_xml_writer.c
@@ -66,7 +66,7 @@ rb_data_type_t ov_xml_writer_type = {
         .dmark = ov_xml_writer_mark,
         .dfree = ov_xml_writer_free,
         .dsize = NULL,
-        .reserved = { NULL, NULL }
+        .reserved = { NULL }
     },
 #ifdef RUBY_TYPED_FREE_IMMEDIATELY
     .parent = NULL,
@@ -181,7 +181,7 @@ static VALUE ov_xml_writer_string(VALUE self) {
     if (rc < 0) {
         rb_raise(ov_error_class, "Can't flush XML writer");
     }
-    return rb_funcall(ptr->io, STRING_ID, 0, NULL);
+    return rb_funcall(ptr->io, STRING_ID, 0, Qnil);
 }
 
 static VALUE ov_xml_writer_write_start(VALUE self, VALUE name) {


### PR DESCRIPTION
Fix (almost) all compiler warnings and errors.
This makes the project builds again on newer Clang compiler.