### PR TITLE
Maven central update

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -84,7 +84,7 @@ And in Debian or Ubuntu:
 
 Once all the requirements are installed the SDK can be built as follows:
 
-  $ git clone git://gerrit.ovirt.org/ovirt-engine-sdk-ruby
+  $ git clone git@github.com:oVirt/ovirt-engine-sdk-ruby.git
   $ cd ovirt-engine-sdk-ruby
   $ mvn package
 

--- a/automation/build-artifacts.sh
+++ b/automation/build-artifacts.sh
@@ -12,27 +12,6 @@ cleanup_artifacts() {
   rm -rf $ARTIFACTS_PATH rpmbuild *.tar.gz *.gem *.spec
 }
 
-mvn_write_settings() {
-  cat >$1 <<EOS
-<?xml version="1.0"?>
-<settings>
-  <mirrors>
-    <mirror>
-      <id>ovirt-artifactory</id>
-      <url>http://artifactory.ovirt.org/artifactory/ovirt-mirror</url>
-      <mirrorOf>*</mirrorOf>
-    </mirror>
-
-    <mirror>
-      <id>maven-central</id>
-      <url>https://repo.maven.apache.org/maven2</url>
-      <mirrorOf>*</mirrorOf>
-    </mirror>
-  </mirrors>
-</settings>
-EOS
-}
-
 git_commit() {
   local commit=$(git log -1 --oneline)
   (echo $commit | grep -Eq "^$1$") && echo $commit || return 1

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,20 @@ limitations under the License.
     </license>
   </licenses>
 
+  <repositories>
+    <repository>
+      <name>Central Portal Snapshots</name>
+      <id>central-portal-snapshots</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <developers>
     <developer>
       <name>Juan Hernandez</name>
@@ -63,8 +77,8 @@ limitations under the License.
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Version of the metamodel and model used to generate the SDK: -->
-    <metamodel.version>1.3.10</metamodel.version>
-    <model.version>4.6.0</model.version>
+    <metamodel.version>1.3.11-SNAPSHOT</metamodel.version>
+    <model.version>4.6.1-SNAPSHOT</model.version>
 
   </properties>
 
@@ -151,16 +165,5 @@ limitations under the License.
     </profile>
 
   </profiles>
-
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-    </repository>
-  </distributionManagement>
 
 </project>


### PR DESCRIPTION
## Changes introduced with this PR

*  Drop deprecated OSSRH snapshot repositories and implement new version.
* Use most recent versions of api model and metamodel for sdk.
* use github in documentation instead of gerrit
